### PR TITLE
Move convert-to method for boolean to the correct namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ keywords.
 
 Parameters also have options:
  * `:type`: specifies the type of the resulting value. Currently, only `:any`, 
-   `:string` and `:integer` are supported although the conversions are 
+   `:string`, `:boolean` and `:integer` are supported although the conversions are 
    extensible as detailed in the advanced usage section below. Defaults to 
    `:any`, performing no conversion of the looked up values.
  * `:nilable`: whether the parameter can be `nil`. Either `true` or 

--- a/src/configurati/conversions.clj
+++ b/src/configurati/conversions.clj
@@ -8,5 +8,8 @@
 (defmethod convert-to :string [_ value]
   (when (some? value) (String/valueOf value)))
 
+(defmethod convert-to :boolean [_ value]
+  (if (#{"true" true} value) true false))
+
 (defmethod convert-to :default [_ value]
   value)

--- a/src/configurati/middleware.clj
+++ b/src/configurati/middleware.clj
@@ -20,9 +20,7 @@
                {:decode-key-fn key-fn})))
          parameters-to-parse (set (get opts :only))]
      (fn [source parameter-name]
-       (let [
-
-             parameter-value (get source parameter-name)]
+       (let [parameter-value (get source parameter-name)]
          (if (or (empty? parameters-to-parse)
                (parameters-to-parse parameter-name))
            (parse-fn parameter-value)

--- a/test/configurati/core_test.clj
+++ b/test/configurati/core_test.clj
@@ -27,9 +27,6 @@
    [clojure.string :as string])
   (:import [clojure.lang ExceptionInfo]))
 
-(defmethod convert-to :boolean [_ value]
-  (if (#{"true" true} value) true false))
-
 (deftest configuration-parameters
   (testing "construction"
     (is (= [:parameter (map->ConfigurationParameter


### PR DESCRIPTION
The conversion from string to boolean doesn't work. It seems the multi-method implementation is not defined in the `conversions` namespace but in a test file.